### PR TITLE
Update calibrate.py

### DIFF
--- a/mpinterfaces/calibrate.py
+++ b/mpinterfaces/calibrate.py
@@ -279,7 +279,7 @@ class Calibrate(MSONable):
         elif type(val) == dict:
             return self.potcar_to_name(val)
         elif isinstance(val, Poscar):
-            return val.comment
+            return val.comment.replace(' ','_').replace('\t','_')
         else:
             return str(val)
 


### PR DESCRIPTION
Line 282 changed from:
return val.comment
to
return val.comment.replace(' ','_').replace('\t','_')
to provide a temporary fix for the bug that creates folders with space characters in the folder name.