### PR TITLE
Compatibility of instrument.py with newer pymatgen versions

### DIFF
--- a/mpinterfaces/instrument.py
+++ b/mpinterfaces/instrument.py
@@ -17,7 +17,10 @@ import subprocess
 import logging
 
 from pymatgen.io.vasp.inputs import Incar, Poscar, Potcar, Kpoints
-from pymatgen.io.vasp.sets import DictVaspInputSet
+try:
+    from pymatgen.io.vasp.sets import DictVaspInputSet
+except ImportError:
+    from pymatgen.io.vasp.sets import DictSet as DictVaspInputSet
 
 from custodian.custodian import Job, ErrorHandler
 


### PR DESCRIPTION
In pymatgen 4, DictVaspInputSet is called DictSet, so the import in line 20 raises an Import Error. Using a try-except structure fixes the import error while maintaining backwards compatibility with pymatgen 3.